### PR TITLE
fix: fix cache to use the registry one

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,8 +38,8 @@ jobs:
           file: Dockerfile
           target: dumbkv-main
           push: true
-          cache-from: type=gha
-          cache-to: type=gha
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
           tags: |
             ghcr.io/${{ github.repository }}:main
             ghcr.io/${{ github.repository }}:main-${{ github.sha }}


### PR DESCRIPTION
Fix the cache to use the registry one and mode=max to send all parts to the cache when cache-to